### PR TITLE
Feature: Add NATSPEC standard comments to methods

### DIFF
--- a/contracts/IPNS.sol
+++ b/contracts/IPNS.sol
@@ -4,9 +4,7 @@ import "./IPNSSchema.sol";
 
 /**
  * @title Interface for the PNS contract.
- * @author Njoku Emmanuel
- * @author Justice Eziefule
- * @author Joseph Peculiar
+ * @author PNS foundation core
  * @notice This only serves as a function guide for the PNS contract.
  * @dev All function call interfaces are defined here.
  */

--- a/contracts/IPNSSchema.sol
+++ b/contracts/IPNSSchema.sol
@@ -3,9 +3,7 @@ pragma solidity 0.8.9;
 
 /**
  * @title Interface to define the PNS contract schemas.
- * @author Njoku Emmanuel
- * @author Justice Eziefule
- * @author Joseph Peculiar
+ * @author PNS foundation core
  * @notice This only serves as a schema guide for the PNS contract.
  * @dev All contract schemas are defined here.
  */

--- a/contracts/PNS.sol
+++ b/contracts/PNS.sol
@@ -4,9 +4,7 @@ import "./IPNS.sol";
 
 /**
  * @title The contract for phone number service.
- * @author Njoku Emmanuel
- * @author Justice Eziefule
- * @author Joseph Peculiar
+ * @author PNS foundation core
  * @notice You can only interact with the public functions and state definitions.
  * @dev The interface IPNS is inherited which inherits IPNSSchema.
  */


### PR DESCRIPTION
This PR attempts to solve #19 (Method comments should follow NATSPEC standard).

Addition added: Change interface inherited in the `PNS.sol` file from `IPNSSchema` to `IPNS`.

Reasons: 
- `IPNS` already inherits the schemas defined in `IPNSSchema`
- `IPNS` interface function guides is used in `PNS.sol`