### PR TITLE
Test/cleanup contracts (WIP)

### DIFF
--- a/contracts/Interfaces/pns/IPNSGuardian.sol
+++ b/contracts/Interfaces/pns/IPNSGuardian.sol
@@ -31,6 +31,7 @@ interface IPNSGuardian {
 
 	function verifyPhoneHash(
 		bytes32 phoneHash,
+		bytes32 _hashedMessage,
 		bool status,
 		address owner,
 		bytes memory _signature

--- a/contracts/Interfaces/pns/IPNSRegistry.sol
+++ b/contracts/Interfaces/pns/IPNSRegistry.sol
@@ -16,7 +16,7 @@ interface IPNSRegistry is IPNSSchema {
 	 * @param phoneHash The phoneHash to be linked to the record.
 	 * @param owner The address of the owner
 	 */
-	event PhoneRecordCreated(bytes32 indexed phoneHash, address indexed owner);
+	event PhoneRecordCreated(bytes32 indexed phoneHash, string indexed wallet, address indexed owner);
 
 	event PhoneNumberVerified(bytes32 indexed phoneHash, bool status);
 
@@ -59,7 +59,7 @@ interface IPNSRegistry is IPNSSchema {
 
 	// event Transfer(bytes32 indexed phoneHash, address owner);
 
-	function setPhoneRecord(bytes32 phoneHash) external payable;
+	function setPhoneRecord(bytes32 phoneHash, string calldata resolver) external payable;
 
 	function getRecord(bytes32 phoneHash) external view returns (PhoneRecord memory);
 

--- a/contracts/Interfaces/pns/IPNSRegistry.sol
+++ b/contracts/Interfaces/pns/IPNSRegistry.sol
@@ -14,10 +14,9 @@ interface IPNSRegistry is IPNSSchema {
 	/**
 	 * @dev logs the event when a phoneHash record is created.
 	 * @param phoneHash The phoneHash to be linked to the record.
-	 * @param wallet The resolver (address) of the record
 	 * @param owner The address of the owner
 	 */
-	event PhoneRecordCreated(bytes32 indexed phoneHash, string indexed wallet, address indexed owner);
+	event PhoneRecordCreated(bytes32 indexed phoneHash, address indexed owner);
 
 	event PhoneNumberVerified(bytes32 indexed phoneHash, bool status);
 
@@ -60,7 +59,7 @@ interface IPNSRegistry is IPNSSchema {
 
 	// event Transfer(bytes32 indexed phoneHash, address owner);
 
-	function setPhoneRecord(bytes32 phoneHash, string calldata resolver) external payable;
+	function setPhoneRecord(bytes32 phoneHash) external payable;
 
 	function getRecord(bytes32 phoneHash) external view returns (PhoneRecord memory);
 

--- a/contracts/Interfaces/pns/IPNSResolver.sol
+++ b/contracts/Interfaces/pns/IPNSResolver.sol
@@ -24,5 +24,5 @@ interface IPNSResolver is IAddressResolver {
 
 	function getVersion() external view returns (uint32 version);
 
-	function setAddr(bytes32 phoneHash, address addr) external;
+	function setAddr(bytes32 phoneHash, string calldata addr) external;
 }

--- a/contracts/Interfaces/pns/IPNSResolver.sol
+++ b/contracts/Interfaces/pns/IPNSResolver.sol
@@ -24,5 +24,5 @@ interface IPNSResolver is IAddressResolver {
 
 	function getVersion() external view returns (uint32 version);
 
-	function setAddr(bytes32 phoneHash, string calldata addr) external;
+	function setAddr(bytes32 phoneHash, address addr) external;
 }

--- a/contracts/PNSGuardian.sol
+++ b/contracts/PNSGuardian.sol
@@ -9,6 +9,7 @@ import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 
 import './Interfaces/pns/IPNSGuardian.sol';
 import './Interfaces/pns/IPNSRegistry.sol';
+import 'hardhat/console.sol';
 
 /// @title Handles the authentication of the PNS registry
 /// @author  PNS core team
@@ -97,6 +98,7 @@ contract PNSGuardian is Initializable, IPNSGuardian, EIP712Upgradeable {
 		bytes memory prefix = '\x19Ethereum Signed Message:\n32';
 		bytes32 prefixedHashMessage = keccak256(abi.encodePacked(prefix, _hashedMessage));
 		address signer = ECDSA.recover(prefixedHashMessage, _signature);
+		console.log('this is signer from contract', msg.sender);
 
 		require(owner == signer, 'signer does not match signature');
 

--- a/contracts/PNSGuardian.sol
+++ b/contracts/PNSGuardian.sol
@@ -115,14 +115,6 @@ contract PNSGuardian is Initializable, IPNSGuardian, EIP712Upgradeable {
 	}
 
 	/**
-	 * @dev Modifier that permits modifications only by the PNS registry contract
-	 */
-	modifier onlyRegistryContract() {
-		require(msg.sender == registryAddress, 'Only Registry Contract: not allowed ');
-		_;
-	}
-
-	/**
 	 * @dev Modifier that permits modifications only by the PNS guardian verifier.
 	 */
 	modifier onlyGuardianVerifier() {

--- a/contracts/PNSGuardian.sol
+++ b/contracts/PNSGuardian.sol
@@ -9,7 +9,6 @@ import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 
 import './Interfaces/pns/IPNSGuardian.sol';
 import './Interfaces/pns/IPNSRegistry.sol';
-import 'hardhat/console.sol';
 
 /// @title Handles the authentication of the PNS registry
 /// @author  PNS core team
@@ -98,7 +97,6 @@ contract PNSGuardian is Initializable, IPNSGuardian, EIP712Upgradeable {
 		bytes memory prefix = '\x19Ethereum Signed Message:\n32';
 		bytes32 prefixedHashMessage = keccak256(abi.encodePacked(prefix, _hashedMessage));
 		address signer = ECDSA.recover(prefixedHashMessage, _signature);
-		console.log('this is signer from contract', msg.sender);
 
 		require(owner == signer, 'signer does not match signature');
 

--- a/contracts/PNSRegistry.sol
+++ b/contracts/PNSRegistry.sol
@@ -66,8 +66,8 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	 * @dev Sets the record for a phoneHash.
 	 * @param phoneHash The phoneHash to update.
 	 */
-	function setPhoneRecord(bytes32 phoneHash) external payable virtual {
-		_setPhoneRecord(phoneHash);
+	function setPhoneRecord(bytes32 phoneHash, string calldata resolver) external payable virtual {
+		_setPhoneRecord(phoneHash, resolver);
 	}
 
 	/**
@@ -229,19 +229,19 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 		record.creation = block.timestamp;
 	}
 
-	function _setPhoneRecord(bytes32 phoneHash) internal onlyVerified(phoneHash) onlyVerifiedOwner(phoneHash) {
+	function _setPhoneRecord(bytes32 phoneHash, string calldata resolver) internal onlyVerified(phoneHash) onlyVerifiedOwner(phoneHash) {
 		uint256 ethToUSD = priceConverter.convertETHToUSD(msg.value);
 		require(ethToUSD >= registryCostInUSD, 'insufficient balance');
 		//create the record in registry
 		createRecord(msg.sender, phoneHash);
 		//update the address field of eth as default
-		// pnsResolver.setAddr(phoneHash, msg.sender);
+		// pnsResolver.setAddr(phoneHash, resolver);
 
 		// Send the registry cost to the treasury
 		uint256 registryCostInEth = priceConverter.convertUSDToETH(registryCostInUSD);
 		toTreasury(registryCostInEth);
 
-		emit PhoneRecordCreated(phoneHash, msg.sender);
+		emit PhoneRecordCreated(phoneHash, resolver, msg.sender);
 
 		// Refund remaining balance to caller
 		if (ethToUSD > registryCostInUSD) {

--- a/contracts/PNSRegistry.sol
+++ b/contracts/PNSRegistry.sol
@@ -253,7 +253,6 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	}
 
 	function toTreasury(uint256 amount) internal {
-		console.log('ahjbdghdghgdhd', treasuryAddress, amount);
 		(bool sent, ) = treasuryAddress.call{value: amount}('');
 		require(sent, 'Transfer failed.');
 	}

--- a/contracts/PNSRegistry.sol
+++ b/contracts/PNSRegistry.sol
@@ -75,7 +75,7 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	 * @param phoneHash The phoneHash to transfer ownership of.
 	 * @param newOwner The address of the new owner.
 	 */
-	function transfer(bytes32 phoneHash, address newOwner) public virtual authorised(phoneHash) authenticated(phoneHash) {
+	function transfer(bytes32 phoneHash, address newOwner) public virtual authorised(phoneHash) {
 		require(newOwner != address(0x0), 'cannot set owner to the zero address');
 		require(newOwner != address(this), 'cannot set owner to the registry address');
 
@@ -124,8 +124,8 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 		require(ethToUSD >= registryRenewCostInUSD, 'insufficient balance');
 
 		//move to  DAO treasury
-		uint256 registryRenewCostInEth = priceConverter.convertUSDToETH(registryRenewCostInUSD);
-		toTreasury(registryRenewCostInEth);
+		uint256 registryRenewCostInETH = priceConverter.convertUSDToETH(registryRenewCostInUSD);
+		toTreasury(registryRenewCostInETH);
 
 		phoneRegistry[phoneHash].expiration = block.timestamp + EXPIRY_TIME;
 		emit PhoneRecordRenewed(phoneHash);
@@ -285,16 +285,6 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	 */
 	modifier notExpired(bytes32 phoneHash) {
 		require(_hasPassedExpiryTime(phoneHash), 'cannot renew an active record');
-		_;
-	}
-
-	/**
-	 * @dev Permits the function to run only if phone record is still authenticated.
-	 * @param phoneHash The phoneHash of the record to be compared.
-	 */
-	modifier authenticated(bytes32 phoneHash) {
-		bool expiry = _hasPassedExpiryTime(phoneHash);
-		require(!expiry, 'grace period passed');
 		_;
 	}
 

--- a/contracts/dependencies/AddrResolver.sol
+++ b/contracts/dependencies/AddrResolver.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.4;
 import '../Interfaces/profiles/IAddrResolver.sol';
 import '../Interfaces/profiles/IAddressResolver.sol';
 import './ResolverBase.sol';
+import 'hardhat/console.sol';
 
 abstract contract AddrResolver is IAddrResolver, IAddressResolver, ResolverBase {
 	uint256 private constant COIN_TYPE_ETH = 60;
@@ -37,6 +38,7 @@ abstract contract AddrResolver is IAddrResolver, IAddressResolver, ResolverBase 
 		uint256 coinType,
 		bytes memory a
 	) public virtual authorised(phoneHash) {
+		console.log('we are here');
 		emit AddressChanged(phoneHash, coinType, a);
 		if (coinType == COIN_TYPE_ETH) {
 			emit AddrChanged(phoneHash, bytesToAddress(a));
@@ -62,7 +64,7 @@ abstract contract AddrResolver is IAddrResolver, IAddressResolver, ResolverBase 
 		}
 	}
 
-	function addressToBytes(address a) internal pure returns (bytes memory b) {
+	function addressToBytes(address a) internal view returns (bytes memory b) {
 		b = new bytes(20);
 		assembly {
 			mstore(add(b, 32), mul(a, exp(256, 12)))

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -6,6 +6,7 @@ import { ethToWei } from '../test/helpers/base';
 
 async function deployContract() {
   let adminAccount;
+  let treasury;
   let pnsRegistryContract;
   let registryCost = ethToWei('9.99'); // 10 usd
   let registryRenewCost = ethToWei('4.99'); // 5 usd
@@ -19,7 +20,7 @@ async function deployContract() {
 
   console.log(hre.network.name, 'network name');
 
-  [adminAccount] = await ethers.getSigners();
+  [adminAccount, treasury] = await ethers.getSigners();
   const adminAddress = adminAccount.address;
   console.log(adminAddress, 'address');
   console.log('------------------------------------------------');
@@ -96,10 +97,9 @@ async function deployContract() {
       },
     );
   } else {
-    const treasuryAddress = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266';
     pnsRegistryContract = await upgrades.deployProxy(
       PNSRegistryContract,
-      [pnsGuardianContract.address, priceConverter.address, treasuryAddress],
+      [pnsGuardianContract.address, priceConverter.address, treasury.address],
       {
         initializer: 'initialize',
       },

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -60,17 +60,18 @@ describe.only('PNS Registry', () => {
     const balance = await joe.provider.getBalance(joe.address);
     console.log(weiToEth(balance));
 
-    const value = {
-      phoneHash: phoneNumber1,
-    };
-    const sig = await joe._signTypedData(domain, PNSTypes, value);
-    console.log('this is signature', sig);
+    console.log('this is address', joe.address);
+    //joe encounters an error while verifying his phone number
+    await expect(
+      pnsGuardianContract.verifyPhoneHash(phoneNumber1, hashedMessage, status, emma.address, signature),
+    ).to.be.revertedWith('signer does not match signature');
     //joe verifies his phone number successfully
-    await expect(pnsGuardianContract.verifyPhoneHash(phoneNumber1, status, joe.address, sig)).to.not.be.reverted;
+    await expect(pnsGuardianContract.verifyPhoneHash(phoneNumber1, hashedMessage, status, joe.address, signature)).to
+      .not.be.reverted;
 
     //joe's record authenticated successfully by guardian
-    let joeVerificationStatus = await pnsRegistryContract.getVerificationStatus(phoneNumber1);
-    await expect(joeVerificationStatus).to.be.equal(true);
+    // let joeVerificationStatus = await pnsRegistryContract.getVerificationStatus(phoneNumber1);
+    // await expect(joeVerificationStatus).to.be.equal(true);
 
     //joe's verification record is owned by joe
     // let verificationOwner = await pnsGuardianContract.getVerifiedOwner(phoneNumber1);
@@ -78,9 +79,9 @@ describe.only('PNS Registry', () => {
     // await expect(verificationOwner).to.be.equal(joe.address);
 
     //joe attempts to create a record with an unverified phone number
-    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber2, joe.address)).to.be.revertedWith(
-      'phone record is not verified',
-    );
+    // await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber2, joe.address)).to.be.revertedWith(
+    //   'phone record is not verified',
+    // );
 
     //joe retries with a verified phone number but forget to add balance
     // await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1, joe.address)).to.be.revertedWith(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -80,25 +80,24 @@ describe.only('PNS Registry', () => {
     assert.equal(owner, joe.address);
 
     //joe encounters an error when attempting to create a record with an unverified phone number
-    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber2)).to.be.revertedWith(
+    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber2, joe.address)).to.be.revertedWith(
       'phone record is not verified',
     );
 
     //joe encounters an error when attempting to create a record when connected to the wrong owner
-    await expect(pnsRegistryContract.connect(emma).setPhoneRecord(phoneNumber1)).to.be.revertedWith(
+    await expect(pnsRegistryContract.connect(emma).setPhoneRecord(phoneNumber1, joe.address)).to.be.revertedWith(
       'caller is not verified owner',
     );
 
     //joe encounters an error when attempting to create a record with an insufficient balance
-    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1)).to.be.revertedWith(
+    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1, joe.address)).to.be.revertedWith(
       'insufficient balance',
     );
 
     //joe creates a record successfully
-    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1, { value: ethToWei('1') })).to.emit(
-      pnsRegistryContract,
-      'PhoneRecordCreated',
-    );
+    await expect(
+      pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1, joe.address, { value: ethToWei('1') }),
+    ).to.emit(pnsRegistryContract, 'PhoneRecordCreated');
 
     //Balance Checks
     const joeBalance = await joe.provider.getBalance(joe.address);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -47,7 +47,7 @@ describe.only('PNS Registry', () => {
     adminAddress = _adminAddress;
   });
 
-  it('Should register a phone number on PNS and set record', async () => {
+  it('Should verify a phone number', async () => {
     const [joe, emma] = accounts.slice(1, 5);
     const joeInitialBalance = await joe.provider.getBalance(joe.address);
     const emmaInitialBalance = await emma.provider.getBalance(emma.address);
@@ -72,6 +72,10 @@ describe.only('PNS Registry', () => {
     //joe verifies that his ownership is verified correctly
     const owner = await pnsGuardianContract.getVerifiedOwner(phoneNumber1);
     assert.equal(owner, joe.address);
+  });
+
+  it('Should create a phone record successfully', async () => {
+    const [joe, emma] = accounts.slice(1, 5);
 
     //joe encounters an error when attempting to create a record with an unverified phone number
     await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber2, joe.address)).to.be.revertedWith(
@@ -97,6 +101,10 @@ describe.only('PNS Registry', () => {
     //joe verifies that the record exist and the ownership is set correctly
     let record = await pnsRegistryContract.getRecord(phoneNumber1);
     assert.equal(record.owner, joe.address);
+  });
+
+  it('Should transfer ownership to another address', async () => {
+    const [joe, emma] = accounts.slice(1, 5);
 
     //joe encounters an error when trying to transfer ownership using the wrong owner
     await expect(pnsRegistryContract.connect(emma).transfer(phoneNumber1, emma.address)).to.be.revertedWith(
@@ -120,8 +128,12 @@ describe.only('PNS Registry', () => {
     );
 
     //emma verifies that the ownership is set correctly
-    record = await pnsRegistryContract.getRecord(phoneNumber1);
+    const record = await pnsRegistryContract.getRecord(phoneNumber1);
     assert.equal(record.owner, emma.address);
+  });
+
+  it('Should renew an expired record', async () => {
+    const [joe, emma] = accounts.slice(1, 5);
 
     //emma encounters an error when trying to renew record before expiration
     await expect(pnsRegistryContract.connect(emma).renew(phoneNumber1)).to.be.revertedWith(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -60,14 +60,20 @@ describe.only('PNS Registry', () => {
     const balance = await joe.provider.getBalance(joe.address);
     console.log(weiToEth(balance));
 
-    console.log('this is address', joe.address);
-    //joe encounters an error while verifying his phone number
+    //joe encounters an error while verifying his phone number with a wrong owner
     await expect(
       pnsGuardianContract.verifyPhoneHash(phoneNumber1, hashedMessage, status, emma.address, signature),
     ).to.be.revertedWith('signer does not match signature');
+
+    //joe encounters an error while verifying his phone number with a wrong verifier
+    await expect(
+      pnsGuardianContract.connect(joe).verifyPhoneHash(phoneNumber1, hashedMessage, status, emma.address, signature),
+    ).to.be.revertedWith('Only Guardian Verifier');
+
     //joe verifies his phone number successfully
-    await expect(pnsGuardianContract.verifyPhoneHash(phoneNumber1, hashedMessage, status, joe.address, signature)).to
-      .not.be.reverted;
+    await expect(
+      pnsGuardianContract.verifyPhoneHash(phoneNumber1, hashedMessage, status, joe.address, signature),
+    ).to.emit(pnsGuardianContract, 'PhoneVerified');
 
     //joe's record authenticated successfully by guardian
     // let joeVerificationStatus = await pnsRegistryContract.getVerificationStatus(phoneNumber1);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -80,24 +80,25 @@ describe.only('PNS Registry', () => {
     assert.equal(owner, joe.address);
 
     //joe encounters an error when attempting to create a record with an unverified phone number
-    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber2, joe.address)).to.be.revertedWith(
+    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber2)).to.be.revertedWith(
       'phone record is not verified',
     );
 
     //joe encounters an error when attempting to create a record when connected to the wrong owner
-    await expect(pnsRegistryContract.connect(emma).setPhoneRecord(phoneNumber1, joe.address)).to.be.revertedWith(
+    await expect(pnsRegistryContract.connect(emma).setPhoneRecord(phoneNumber1)).to.be.revertedWith(
       'caller is not verified owner',
     );
 
     //joe encounters an error when attempting to create a record with an insufficient balance
-    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1, joe.address)).to.be.revertedWith(
+    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1)).to.be.revertedWith(
       'insufficient balance',
     );
 
     //joe creates a record successfully
-    // await expect(
-    //   pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1, joe.address, { value: ethToWei('0.1') }),
-    // ).to.emit(pnsRegistryContract, 'PhoneRecordCreated');
+    await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1, { value: ethToWei('1') })).to.emit(
+      pnsRegistryContract,
+      'PhoneRecordCreated',
+    );
 
     //joe retries with a verified phone number but forget to add balance
     // await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1, joe.address)).to.be.revertedWith(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -57,8 +57,8 @@ describe.only('PNS Registry', () => {
 
   it('Should register a phone number on PNS and set record', async () => {
     const [joe, emma] = accounts.slice(1, 5);
-    const balance = await joe.provider.getBalance(joe.address);
-    console.log(weiToEth(balance));
+    const joeInitialBalance = await joe.provider.getBalance(joe.address);
+    console.log("Joe's initial balance:::", joeInitialBalance);
 
     //joe encounters an error while verifying his phone number with a wrong owner
     await expect(
@@ -100,18 +100,9 @@ describe.only('PNS Registry', () => {
       'PhoneRecordCreated',
     );
 
-    //joe retries with a verified phone number but forget to add balance
-    // await expect(pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1, joe.address)).to.be.revertedWith(
-    //   'insufficient balance',
-    // );
+    //Balance Checks
+    const joeBalance = await joe.provider.getBalance(joe.address);
 
-    //joe retries with a balance and creates a record successfully
-    // await expect(
-    //   pnsRegistryContract.connect(joe).setPhoneRecord(phoneNumber1, joe.address, { value: ethToWei('0.1') }),
-    // ).to.emit(pnsRegistryContract, 'PhoneRecordCreated');
-
-    // //Balance Checks
-    // // const joeBalanceBeforeLink = await getEthBalance(joe.address);
-    // const RegistryContractBalance = await getEthBalance(pnsRegistryContract.address);
+    console.log("Joe's balance now:::", joeBalance);
   });
 });


### PR DESCRIPTION
This PR contains integration tests covering guardian, registry, and resolver contracts.

**NOTE**
Minor fixes were made to the registry and guardian contract on the cause of writing these tests;

- Reverted the phone hash recovery process to the previous implementation.

- converted registryCostInUsd to registryCostInEth before passing it to the `toTreasury` method like this `toTreasury(registryCostInEth);` => this was causing an error previously.

- Change the modifier name from `notExpired` to `hasExpired`. The prev implementation requires `_hasPassedExpiryTime` to be false, but we need it to require it to be true. In essence, `throw an error if phone record is not yet expired`.

- Update the `renew` method => move implementation line to send renew cost to treasury up => convert `registryRenewCostInUSD` to `registryRenewCostInETH` and pass it to `toTreasury(registryRenewCostInETH)` => move implementation line to refund user at the bottom.

- Update the modifier `authenticated` to `notExpired`. This allows record ownership transfer to proceed only when record has **NOT** passed its grace period.