### PR TITLE
gas optimizations via packing variables

### DIFF
--- a/contracts/Interfaces/pns/IPNSGuardian.sol
+++ b/contracts/Interfaces/pns/IPNSGuardian.sol
@@ -17,8 +17,9 @@ interface IPNSGuardian {
 	 */
 	event PhoneVerified(address indexed owner, bytes32 indexed phoneHash, uint256 verifiedAt);
 
+	// store in 1 slot, bool is a flexible type and will occupy the space left for it if any or take up a full slot if not packable
 	struct VerificationRecord {
-		uint256 verifiedAt;
+		uint48 verifiedAt;
 		bool isVerified;
 		address owner;
 	}

--- a/contracts/Interfaces/pns/IPNSResolver.sol
+++ b/contracts/Interfaces/pns/IPNSResolver.sol
@@ -12,10 +12,13 @@ import '../profiles/IAddressResolver.sol';
  * @dev All function call interfaces are defined here.
  */
 interface IPNSResolver is IAddressResolver {
+	// storing expiration and creation as uint48s saves gas as calling the mapping that returns this slot only has to do 1 sloads under the hood
+	// addresses are uint160s by default and so can be packed with uint96 which is (uint48 * 2)
+	// this is safe to when using it as a time variable as uint48,max is the year 8,927,483 AD
 	struct PhoneRecord {
 		address owner;
-		uint256 expiration;
-		uint256 creation;
+		uint48 expiration;
+		uint48 creation;
 	}
 
 	function getOwner(bytes32 phoneHash) external view returns (address);

--- a/contracts/Interfaces/pns/IPNSSchema.sol
+++ b/contracts/Interfaces/pns/IPNSSchema.sol
@@ -10,7 +10,7 @@ pragma solidity 0.8.9;
 interface IPNSSchema {
 	struct PhoneRecord {
 		address owner;
-		uint256 expiration;
-		uint256 creation;
+		uint48 expiration;
+		uint48 creation;
 	}
 }

--- a/contracts/PNSGuardian.sol
+++ b/contracts/PNSGuardian.sol
@@ -14,8 +14,6 @@ import './Interfaces/pns/IPNSRegistry.sol';
 /// @author  PNS core team
 /// @notice The PNS Guardian is responsible for authenticating the records created in PNS registry
 contract PNSGuardian is Initializable, IPNSGuardian, EIP712Upgradeable {
-	/// the guardian layer address that updates verification state
-	address public registryAddress;
 	/// PNS registry
 	IPNSRegistry public registryContract;
 	/// Address of off chain verifier
@@ -103,12 +101,16 @@ contract PNSGuardian is Initializable, IPNSGuardian, EIP712Upgradeable {
 
 		if (verificationRecord.owner == address(0)) {
 			verificationRecord.owner = signer;
-			verificationRecord.verifiedAt = block.timestamp;
+			verificationRecord.verifiedAt = uint48(block.timestamp);
 			verificationRecord.isVerified = status;
 		}
 
 		emit PhoneVerified(signer, phoneHash, block.timestamp);
 		return verificationRecord.owner != address(0);
+	}
+
+	function registryAddress() public view returns (address) {
+		return address(registryContract);
 	}
 
 	/**

--- a/contracts/PNSGuardian.sol
+++ b/contracts/PNSGuardian.sol
@@ -109,10 +109,6 @@ contract PNSGuardian is Initializable, IPNSGuardian, EIP712Upgradeable {
 		return verificationRecord.owner != address(0);
 	}
 
-	function registryAddress() public view returns (address) {
-		return address(registryContract);
-	}
-
 	/**
 	 * @dev Modifier that permits modifications only by the PNS guardian verifier.
 	 */

--- a/contracts/PNSRegistry.sol
+++ b/contracts/PNSRegistry.sol
@@ -127,7 +127,7 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 		uint256 registryRenewCostInETH = priceConverter.convertUSDToETH(registryRenewCostInUSD);
 		toTreasury(registryRenewCostInETH);
 
-		phoneRegistry[phoneHash].expiration = block.timestamp + EXPIRY_TIME;
+		phoneRegistry[phoneHash].expiration = uint48(block.timestamp + EXPIRY_TIME);
 		emit PhoneRecordRenewed(phoneHash);
 
 		//refund user if excessive
@@ -228,8 +228,8 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	function createRecord(address owner, bytes32 phoneHash) internal {
 		PhoneRecord storage record = phoneRegistry[phoneHash];
 		record.owner = owner;
-		record.expiration = block.timestamp + EXPIRY_TIME;
-		record.creation = block.timestamp;
+		record.expiration = uint48(block.timestamp + EXPIRY_TIME);
+		record.creation = uint48(block.timestamp);
 	}
 
 	function _setPhoneRecord(bytes32 phoneHash, address resolver) internal onlyVerified(phoneHash) onlyVerifiedOwner(phoneHash) {

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -114,7 +114,7 @@ async function deployContract() {
   await pnsRegistryContract.setRegistryRenewCost(registryRenewCost);
   const pnsRegistryRenewCost = await pnsRegistryContract.registryRenewCostInUSD();
   await pnsGuardianContract.setPNSRegistry(pnsRegistryContract.address);
-  const guardianRegistry = await pnsGuardianContract.registryAddress();
+  const guardianRegistry = await pnsGuardianContract.registryContract();
   console.log('Registry contract in guardian after deployment', guardianRegistry);
   console.log('------------------------------------------------');
   console.log(


### PR DESCRIPTION
Same as [PR 76](https://github.com/pnslabs/pns-contracts/pull/76) 
Packed struct variables safe gas when they're accessed within the same function call. Reduces number of SSLOADs

The tests pass too