### PR TITLE
Add Natspec comments to registry contract and improve contract structure

### DIFF
--- a/contracts/PNSRegistry.sol
+++ b/contracts/PNSRegistry.sol
@@ -22,35 +22,42 @@ import 'hardhat/console.sol';
 
 contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	// using AddressUpgradeable for address payable;
-	/// Expiry time value
-	uint256 public constant EXPIRY_TIME = 365 days;
-	/// Grace period value
-	uint256 public gracePeriod;
-	/// registry cost
-	uint256 public registryCostInUSD;
-	/// registry renew cost
-	uint256 public registryRenewCostInUSD;
 
+	//============STATE VARIABLES==============
+	// Expiry time value
+	uint256 public constant EXPIRY_TIME = 365 days;
+	// Grace period value
+	uint256 public gracePeriod;
+
+	// Registry cost in USD
+	uint256 public registryCostInUSD;
+	// Registry renew cost in USD
+	uint256 public registryRenewCostInUSD;
+	// Address of the treasury
 	address public treasuryAddress;
-	/// Oracle feed pricing
+
+	// Oracle feed pricing
 	IPriceConverter public priceConverter;
+	// Address of the PNS guardian contract
 	IPNSGuardian public pnsGuardian;
+	// Address of the PNS resolver contract
 	IPNSResolver public pnsResolver;
 
-	/// Mapping state to store mobile phone number record that will be linked to a resolver
+	// Mapping to store phone number record linked to a resolver
 	mapping(bytes32 => PhoneRecord) public phoneRegistry;
 
-	/// Create a new role identifier for the minter role
+	// Create a new role identifier for the maintainer role
 	bytes32 public constant MAINTAINER_ROLE = keccak256('MAINTAINER_ROLE');
 
+	//============EXTERNAL FUNCTIONS==============
+
 	/**
-	 * @dev contract initializer function. This function exist because the contract is upgradable.
+	 * @dev Initializes the contract.
+	 * @param _pnsGuardian Address of the PNSGuardian contract.
+	 * @param _priceConverter Address of the IPriceConverter contract.
+	 * @param _treasuryAddress Address of the treasury.
 	 */
-	function initialize(
-		address _pnsGuardian,
-		address _priceConverter,
-		address _treasuryAddress
-	) external initializer {
+	function initialize(address _pnsGuardian, address _priceConverter, address _treasuryAddress) external initializer {
 		__AccessControl_init();
 		//set oracle constant
 		gracePeriod = 60 days;
@@ -63,24 +70,12 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	}
 
 	/**
-	 * @dev Sets the record for a phoneHash.
-	 * @param phoneHash The phoneHash to update.
+	 * @dev Sets the record for a phone number hash.
+	 * @param phoneHash The phone number hash to update.
+	 * @param resolver The address the phone number resolves to.
 	 */
 	function setPhoneRecord(bytes32 phoneHash, address resolver) external payable virtual {
 		_setPhoneRecord(phoneHash, resolver);
-	}
-
-	/**
-	 * @dev Transfers ownership of a phoneHash to a new address. Can only be called by the current owner of the phoneHash.
-	 * @param phoneHash The phoneHash to transfer ownership of.
-	 * @param newOwner The address of the new owner.
-	 */
-	function transfer(bytes32 phoneHash, address newOwner) public virtual authorised(phoneHash) notExpired(phoneHash) {
-		require(newOwner != address(0x0), 'cannot set owner to the zero address');
-		require(newOwner != address(this), 'cannot set owner to the registry address');
-
-		phoneRegistry[phoneHash].owner = newOwner;
-		emit Transfer(phoneHash, newOwner);
 	}
 
 	/**
@@ -92,24 +87,49 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 		emit changeGracePeriod(msg.sender, time);
 	}
 
+	/**
+	 * @dev Sets the registry cost in USD.
+	 * @param _registryCostInUSD The new registry cost in USD.
+	 */
 	function setRegistryCost(uint256 _registryCostInUSD) external onlySystemRoles {
 		//double check : convert amount entered to wei value;
 		registryCostInUSD = _registryCostInUSD;
 	}
 
+	/**
+	 * @dev Sets the cost in USD for renewing a registry.
+	 * @param _registryRenewCostInUSD The new cost for renewing a registry in USD.
+	 * @notice The amount entered will be converted to its corresponding value in wei.
+	 * @notice Only system roles are allowed to call this function.
+	 */
 	function setRegistryRenewCost(uint256 _registryRenewCostInUSD) external onlySystemRoles {
 		//double check : convert amount entered to wei value;
 		registryRenewCostInUSD = _registryRenewCostInUSD;
 	}
 
+	/**
+	 * @dev Sets the treasury address.
+	 * @param _treasuryAddress The new treasury address.
+	 * @notice Only system roles are allowed to call this function.
+	 */
 	function setTreasuryAddress(address _treasuryAddress) external onlySystemRoles {
 		treasuryAddress = _treasuryAddress;
 	}
 
+	/**
+	 * @dev Sets the new PNS guardian address.
+	 * @param _newGuardianAddress The new PNS guardian address.
+	 * @notice Only system roles are allowed to call this function.
+	 */
 	function setGuardian(address _newGuardianAddress) external onlySystemRoles {
 		pnsGuardian = IPNSGuardian(_newGuardianAddress);
 	}
 
+	/**
+	 * @dev Sets the new PNS resolver address.
+	 * @param _newResolverAddress The new PNS resolver address.
+	 * @notice Only system roles are allowed to call this function.
+	 */
 	function setResolver(address _newResolverAddress) external onlySystemRoles {
 		pnsResolver = IPNSResolver(_newResolverAddress);
 	}
@@ -117,6 +137,7 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	/**
 	 * @dev Renew a phone record.
 	 * @param phoneHash The phoneHash.
+	 * @notice The phone record must have expired and the user must be authorized to modify it.
 	 */
 	function renew(bytes32 phoneHash) external payable virtual authorised(phoneHash) hasExpired(phoneHash) {
 		//convert to wei
@@ -151,17 +172,9 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	 * @dev Returns the PhoneRecord data linked to the specified phone number hash.
 	 * @param phoneHash The specified phoneHash.
 	 */
-	function getRecordFull(bytes32 phoneHash)
-		external
-		view
-		returns (
-			address owner,
-			bool isExpired,
-			bool isInGracePeriod,
-			uint256 expiration,
-			uint256 creation
-		)
-	{
+	function getRecordFull(
+		bytes32 phoneHash
+	) external view returns (address owner, bool isExpired, bool isInGracePeriod, uint256 expiration, uint256 creation) {
 		recordExists(phoneHash);
 		PhoneRecord memory record = phoneRegistry[phoneHash];
 		isInGracePeriod = _hasPassedExpiryTime(phoneHash);
@@ -171,52 +184,19 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 		owner = record.owner;
 	}
 
+	/**
+	 * @dev Retrieves the phone record for a given phone hash.
+	 * @param phoneHash The phone hash to retrieve the record for.
+	 * @return The phone record for the given phone hash.
+	 */
 	function getRecord(bytes32 phoneHash) external view returns (PhoneRecord memory) {
 		return phoneRegistry[phoneHash];
 	}
 
-	function getVerificationStatus(bytes32 phoneHash) public view returns (bool) {
-		bool status = pnsGuardian.getVerificationStatus(phoneHash);
-		return status;
-	}
-
 	/**
-	 * @dev Checks if the specified phoneHash is verified.
-	 * @param phoneHash The phoneHash to update.
-	 */
-	function isRecordVerified(bytes32 phoneHash) public view returns (bool) {
-		return getVerificationStatus(phoneHash);
-	}
-
-	/**
-	 * @dev Returns whether a record has been imported to the registry.
-	 * @param phoneHash The specified phoneHash.
-	 * @return Bool if record exists
-	 */
-	function recordExists(bytes32 phoneHash) public view returns (bool) {
-		return phoneRegistry[phoneHash].owner != address(0);
-	}
-
-	/**
-	 * @dev Returns the expiry state of an existing phone record.
-	 * @param phoneHash The specified phoneHash.
-	 */
-	function _hasPassedExpiryTime(bytes32 phoneHash) public view returns (bool) {
-		return block.timestamp > phoneRegistry[phoneHash].expiration;
-	}
-
-	/**
-	 * @dev Returns the grace period state of an existing phone record.
-	 * @param phoneHash The specified phoneHash.
-	 */
-	function _hasPassedGracePeriod(bytes32 phoneHash) public view returns (bool) {
-		return block.timestamp > (phoneRegistry[phoneHash].expiration + gracePeriod);
-	}
-
-	/**
-	 * @dev Withdraws funds from the protocol contract
-	 * @param amount The amount to withdraw
-	 * @param _recipient The recipient of the funds
+	 * @dev Allows the system roles to withdraw funds from the contract and send them to a recipient.
+	 * @param _recipient The address to send the funds to.
+	 * @param amount The amount of funds to send.
 	 */
 	function withdraw(address _recipient, uint256 amount) external onlySystemRoles {
 		require(amount > 0, 'amount must be greater than zero');
@@ -225,6 +205,74 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 		emit WithdrawalSuccessful(_recipient, amount);
 	}
 
+	//============PUBLIC FUNCTIONS==============
+
+	/**
+	 * @dev Transfers ownership of a phoneHash to a new address. Can only be called by the current owner of the phoneHash.
+	 * @param phoneHash The phoneHash to transfer ownership of.
+	 * @param newOwner The address of the new owner.
+	 */
+	function transfer(bytes32 phoneHash, address newOwner) public virtual authorised(phoneHash) notExpired(phoneHash) {
+		require(newOwner != address(0x0), 'cannot set owner to the zero address');
+		require(newOwner != address(this), 'cannot set owner to the registry address');
+
+		phoneRegistry[phoneHash].owner = newOwner;
+		emit Transfer(phoneHash, newOwner);
+	}
+
+	/**
+	 * @dev Retrieves the verification status for a given phone hash from the PNS guardian contract.
+	 * @param phoneHash The phone hash to retrieve the verification status for.
+	 * @return A boolean indicating the verification status for the given phone hash.
+	 */
+	function getVerificationStatus(bytes32 phoneHash) public view returns (bool) {
+		bool status = pnsGuardian.getVerificationStatus(phoneHash);
+		return status;
+	}
+
+	/**
+	 * @dev Checks if the specified phoneHash is verified.
+	 * @param phoneHash The phone hash to check verification status for.
+	 * @return A boolean indicating whether the phone record is verified or not.
+	 */
+	function isRecordVerified(bytes32 phoneHash) public view returns (bool) {
+		return getVerificationStatus(phoneHash);
+	}
+
+	/**
+	 * @dev Returns whether a given phone hash exists in the phone registry
+	 * @param phoneHash The specified phoneHash.
+	 * @return A boolean indicating whether a phone record exists.
+	 */
+	function recordExists(bytes32 phoneHash) public view returns (bool) {
+		return phoneRegistry[phoneHash].owner != address(0);
+	}
+
+	/**
+	 * @dev Checks whether a phone record has passed its expiry time.
+	 * @param phoneHash The specified phoneHash.
+	 * @return A boolean indicating whether the phonehash has expired.
+	 */
+	function _hasPassedExpiryTime(bytes32 phoneHash) public view returns (bool) {
+		return block.timestamp > phoneRegistry[phoneHash].expiration;
+	}
+
+	/**
+	 * @dev Checks whether a phone record has passed its grace period.
+	 * @param phoneHash The hash of the phone number to check.
+	 * @return A boolean indicating whether the phone record has passed its grace period.
+	 */
+	function _hasPassedGracePeriod(bytes32 phoneHash) public view returns (bool) {
+		return block.timestamp > (phoneRegistry[phoneHash].expiration + gracePeriod);
+	}
+
+	//============INTERNAL FUNCTIONS==============
+
+	/**
+	 * @dev Creates a phone record with the specified owner and phone number hash.
+	 * @param owner The owner address of the phone record.
+	 * @param phoneHash The hash of the phone number to create the record for.
+	 */
 	function createRecord(address owner, bytes32 phoneHash) internal {
 		PhoneRecord storage record = phoneRegistry[phoneHash];
 		record.owner = owner;
@@ -232,6 +280,11 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 		record.creation = block.timestamp;
 	}
 
+	/**
+	 * @dev Sets the phone record with the specified phone number hash to the specified resolver address.
+	 * @param phoneHash The hash of the phone number to set the record for.
+	 * @param resolver The resolver address to set for the phone record.
+	 */
 	function _setPhoneRecord(bytes32 phoneHash, address resolver) internal onlyVerified(phoneHash) onlyVerifiedOwner(phoneHash) {
 		uint256 ethToUSD = priceConverter.convertETHToUSD(msg.value);
 		require(ethToUSD >= registryCostInUSD, 'insufficient balance');
@@ -257,6 +310,10 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 		}
 	}
 
+	/**
+	 * @dev Sends the specified amount of Ether to the DAO treasury.
+	 * @param amount The amount of Ether to send to the treasury.
+	 */
 	function toTreasury(uint256 amount) internal {
 		(bool sent, ) = treasuryAddress.call{value: amount}('');
 		require(sent, 'Transfer failed.');
@@ -272,6 +329,7 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	}
 
 	//============MODIFIERS==============
+
 	/**
 	 * @dev Permits modifications only by the owner of the specified phoneHash.
 	 * @param phoneHash The phoneHash of the record owner to be compared.
@@ -299,18 +357,29 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 		_;
 	}
 
+	/**
+	 * @dev Modifier to check if the phone record is verified
+	 * @param phoneHash The hash of the phone number record to check
+	 */
 	modifier onlyVerified(bytes32 phoneHash) {
 		bool status = pnsGuardian.getVerificationStatus(phoneHash);
 		require(status, 'phone record is not verified');
 		_;
 	}
 
+	/**
+	 * @dev Modifier to check if the caller is the verified owner of the phone record
+	 * @param phoneHash The hash of the phone number record to check
+	 */
 	modifier onlyVerifiedOwner(bytes32 phoneHash) virtual {
 		address owner = pnsGuardian.getVerifiedOwner(phoneHash);
 		require(owner == msg.sender, 'caller is not verified owner');
 		_;
 	}
 
+	/**
+	 * @dev Modifier to check if the caller has system roles (maintainer or default admin)
+	 */
 	modifier onlySystemRoles() {
 		require(hasRole(MAINTAINER_ROLE, msg.sender) || hasRole(DEFAULT_ADMIN_ROLE, msg.sender), 'not allowed to execute function');
 		_;

--- a/contracts/PNSRegistry.sol
+++ b/contracts/PNSRegistry.sol
@@ -169,9 +169,14 @@ contract PNSRegistry is Initializable, AccessControlUpgradeable, IPNSRegistry {
 	}
 
 	/**
-	 * @dev Returns the PhoneRecord data linked to the specified phone number hash.
-	 * @param phoneHash The specified phoneHash.
-	 */
+	* @dev Retrieves the full record of a phone number, including its owner, expiration date, creation date, and whether it is currently expired or in grace period.
+	* @param phoneHash The hash of the phone number to retrieve the record for.
+	* @return owner The address of the current owner of the phone number.
+	* @return isExpired A boolean indicating whether the phone number is currently expired.
+	* @return isInGracePeriod A boolean indicating whether the phone number is currently in the grace period.
+	* @return expiration The timestamp indicating when the phone number will expire.
+	* @return creation The timestamp indicating when the phone number was first registered.
+	*/
 	function getRecordFull(
 		bytes32 phoneHash
 	) external view returns (address owner, bool isExpired, bool isInGracePeriod, uint256 expiration, uint256 creation) {


### PR DESCRIPTION
The readme documentation I am working on requires I add descriptions to the public or external contract functions. I realized that It will be way easier for me to write the documentation if the contract functions had explicit comments that described them.
I am currently documenting the Registry Contract and so I added and updated some of the Registry Contract function's comments.

Also to improve the overall code structure, I separated the external functions from the public functions using comment separators.

The contract structure now looks like this:
- State variables
- External functions
- Public functions
- Internal functions
- Modifiers